### PR TITLE
Bugfix in XML test

### DIFF
--- a/examples/qa_BasicTest.log
+++ b/examples/qa_BasicTest.log
@@ -1,180 +1,118 @@
--------- Test Results on 2017-02-20 14:14:00 ---------
-Test serie   0: [u'80 0b 01 01 23 45 67 89 ab cd ef'] * 10
-    Test   0 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   5 out of  10 ( 50.00%)
-    Test   1 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-    Test   2 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-  => Total passed: 5 out of 30  (16.67%)
+-------- Test Results on 2017-02-23 09:49:52 ---------
+ ====== Total passed: 75 out of 413  (18.16%) ======
+Ran 1 test in 613.894s
 
-Test serie   1: [u'80 0f 02 01 23 45 67 89 ab cd ef'] * 10
-    Test   0 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-    Test   1 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   4 out of  10 ( 40.00%)
-  => Total passed: 4 out of 20  (20.00%)
+-------- Test Results on 2017-02-23 17:27:48 ---------
+Test serie   0: [u'01 23 45 67 89 ab cd ef'] * 10
+    Test   1 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   5 out of  10 ( 50.00%)
+    Test   2 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   3 out of  10 ( 30.00%)
+    Test   3 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test   4 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test   5 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   4 out of  10 ( 40.00%)
+    Test   6 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test   7 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   2 out of  10 ( 20.00%)
+  => Total passed: 14 out of 70  (20.00%)
 
-Test serie   2: [u'80 0d 05 01 23 45 67 89 ab cd ef'] * 10
-    Test   0 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-    Test   1 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   2 out of  10 ( 20.00%)
-  => Total passed: 2 out of 20  (10.00%)
+Test serie   1: [u'11 11 11'] * 1
+    Test   8 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   1 out of   1 (100.00%)
+    Test   9 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   1 out of   1 (100.00%)
+    Test  10 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  11 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  12 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  13 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  14 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+  => Total passed: 2 out of 7  (28.57%)
 
-Test serie   3: [u'30 0b 02 11 11 11'] * 1
-    Test   0 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   1 out of   1 (100.00%)
-    Test   1 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-    Test   2 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-  => Total passed: 1 out of 3  (33.33%)
+Test serie   2: [u'11 11 11'] * 5
+    Test  15 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   3 out of   5 ( 60.00%)
+    Test  16 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   2 out of   5 ( 40.00%)
+    Test  17 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of   5 (  0.00%)
+    Test  18 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   5 (  0.00%)
+    Test  19 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   2 out of   5 ( 40.00%)
+    Test  20 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   5 (  0.00%)
+    Test  21 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   1 out of   5 ( 20.00%)
+  => Total passed: 8 out of 35  (22.86%)
 
-Test serie   4: [u'30 0f 01 11 11 11'] * 1
-    Test   0 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-    Test   1 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-  => Total passed: 0 out of 2  (0.00%)
+Test serie   3: [u'aa aa aa aa'] * 3
+    Test  22 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   1 out of   3 ( 33.33%)
+    Test  23 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   1 out of   3 ( 33.33%)
+    Test  24 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of   3 (  0.00%)
+    Test  25 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
+    Test  26 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
+    Test  27 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
+    Test  28 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   1 out of   3 ( 33.33%)
+  => Total passed: 3 out of 21  (14.29%)
 
-Test serie   5: [u'30 0d 06 11 11 11'] * 1
-    Test   0 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-    Test   1 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-  => Total passed: 0 out of 2  (0.00%)
+Test serie   4: [u'ff ff ff ff'] * 1
+    Test  29 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  30 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   1 out of   1 (100.00%)
+    Test  31 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  32 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  33 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  34 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  35 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   1 out of   1 (100.00%)
+  => Total passed: 2 out of 7  (28.57%)
 
-Test serie   6: [u'30 0b 02 11 11 11'] * 5
-    Test   0 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   3 out of   5 ( 60.00%)
-    Test   1 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   0 out of   5 (  0.00%)
-    Test   2 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of   5 (  0.00%)
-  => Total passed: 3 out of 15  (20.00%)
+Test serie   5: [u'ff ff ff ff'] * 10
+    Test  36 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   2 out of  10 ( 20.00%)
+    Test  37 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   5 out of  10 ( 50.00%)
+    Test  38 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test  39 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test  40 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test  41 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test  42 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   3 out of  10 ( 30.00%)
+  => Total passed: 10 out of 70  (14.29%)
 
-Test serie   7: [u'30 0f 01 11 11 11'] * 5
-    Test   0 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   5 (  0.00%)
-    Test   1 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   2 out of   5 ( 40.00%)
-  => Total passed: 2 out of 10  (20.00%)
+Test serie   6: [u'55 55 55 55'] * 3
+    Test  43 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   1 out of   3 ( 33.33%)
+    Test  44 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   1 out of   3 ( 33.33%)
+    Test  45 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of   3 (  0.00%)
+    Test  46 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
+    Test  47 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   1 out of   3 ( 33.33%)
+    Test  48 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
+    Test  49 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
+  => Total passed: 3 out of 21  (14.29%)
 
-Test serie   8: [u'30 0d 06 11 11 11'] * 5
-    Test   0 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   5 (  0.00%)
-    Test   1 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   1 out of   5 ( 20.00%)
-  => Total passed: 1 out of 10  (10.00%)
+Test serie   7: [u'55 55 55 55'] * 10
+    Test  50 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   2 out of  10 ( 20.00%)
+    Test  51 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   4 out of  10 ( 40.00%)
+    Test  52 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test  53 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test  54 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   5 out of  10 ( 50.00%)
+    Test  55 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test  56 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   3 out of  10 ( 30.00%)
+  => Total passed: 14 out of 70  (20.00%)
 
-Test serie   9: [u'40 0b 07 aa aa aa aa'] * 3
-    Test   0 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   1 out of   3 ( 33.33%)
-    Test   1 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
-    Test   2 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of   3 (  0.00%)
-  => Total passed: 1 out of 9  (11.11%)
+Test serie   8: [u'88 88 88 88'] * 1
+    Test  57 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  58 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   1 out of   1 (100.00%)
+    Test  59 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  60 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  61 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  62 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
+    Test  63 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   1 out of   1 (100.00%)
+  => Total passed: 2 out of 7  (28.57%)
 
-Test serie  10: [u'40 0f 04 aa aa aa aa'] * 3
-    Test   0 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
-    Test   1 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
-  => Total passed: 0 out of 6  (0.00%)
+Test serie   9: [u'88 88 88 88'] * 5
+    Test  61 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   2 out of   5 ( 40.00%)
+    Test  62 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   2 out of   5 ( 40.00%)
+    Test  63 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   1 out of   5 ( 20.00%)
+    Test  64 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   5 (  0.00%)
+    Test  65 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of   5 (  0.00%)
+    Test  66 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   5 (  0.00%)
+    Test  67 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   1 out of   5 ( 20.00%)
+  => Total passed: 6 out of 35  (17.14%)
 
-Test serie  11: [u'40 0d 03 aa aa aa aa'] * 3
-    Test   0 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
-    Test   1 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   1 out of   3 ( 33.33%)
-  => Total passed: 1 out of 6  (16.67%)
-
-Test serie  12: [u'40 0b 07 ff ff ff ff'] * 1
-    Test   0 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-    Test   1 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-    Test   2 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-  => Total passed: 0 out of 3  (0.00%)
-
-Test serie  13: [u'40 0f 04 ff ff ff ff'] * 1
-    Test   0 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-    Test   1 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-  => Total passed: 0 out of 2  (0.00%)
-
-Test serie  14: [u'40 0d 03 ff ff ff ff'] * 1
-    Test   0 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-    Test   1 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   1 out of   1 (100.00%)
-  => Total passed: 1 out of 2  (50.00%)
-
-Test serie  15: [u'40 0b 07 ff ff ff ff'] * 10
-    Test   0 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   2 out of  10 ( 20.00%)
-    Test   1 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-    Test   2 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-  => Total passed: 2 out of 30  (6.67%)
-
-Test serie  16: [u'40 0f 04 ff ff ff ff'] * 10
-    Test   0 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-    Test   1 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-  => Total passed: 0 out of 20  (0.00%)
-
-Test serie  17: [u'40 0d 03 ff ff ff ff'] * 10
-    Test   0 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-    Test   1 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   3 out of  10 ( 30.00%)
-  => Total passed: 3 out of 20  (15.00%)
-
-Test serie  18: [u'40 0b 07 55 55 55 55'] * 3
-    Test   0 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   1 out of   3 ( 33.33%)
-    Test   1 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
-    Test   2 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of   3 (  0.00%)
-  => Total passed: 1 out of 9  (11.11%)
-
-Test serie  19: [u'40 0f 04 55 55 55 55'] * 3
-    Test   0 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
-    Test   1 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   1 out of   3 ( 33.33%)
-  => Total passed: 1 out of 6  (16.67%)
-
-Test serie  20: [u'40 0d 03 55 55 55 55'] * 3
-    Test   0 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
-    Test   1 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   0 out of   3 (  0.00%)
-  => Total passed: 0 out of 6  (0.00%)
-
-Test serie  21: [u'40 0b 07 55 55 55 55'] * 10
-    Test   0 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   2 out of  10 ( 20.00%)
-    Test   1 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-    Test   2 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-  => Total passed: 2 out of 30  (6.67%)
-
-Test serie  22: [u'40 0f 04 55 55 55 55'] * 10
-    Test   0 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-    Test   1 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   5 out of  10 ( 50.00%)
-  => Total passed: 5 out of 20  (25.00%)
-
-Test serie  23: [u'40 0d 03 55 55 55 55'] * 10
-    Test   0 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-    Test   1 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   3 out of  10 ( 30.00%)
-  => Total passed: 3 out of 20  (15.00%)
-
-Test serie  24: [u'40 0b 07 88 88 88 88'] * 1
-    Test   0 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-    Test   1 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-    Test   2 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-  => Total passed: 0 out of 3  (0.00%)
-
-Test serie  25: [u'40 0f 04 88 88 88 88'] * 1
-    Test   0 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-    Test   1 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-  => Total passed: 0 out of 2  (0.00%)
-
-Test serie  26: [u'40 0d 03 88 88 88 88'] * 1
-    Test   0 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   1 (  0.00%)
-    Test   1 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   1 out of   1 (100.00%)
-  => Total passed: 1 out of 2  (50.00%)
-
-Test serie  27: [u'40 0b 07 88 88 88 88'] * 5
-    Test   0 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   2 out of   5 ( 40.00%)
-    Test   1 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   0 out of   5 (  0.00%)
-    Test   2 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of   5 (  0.00%)
-  => Total passed: 2 out of 15  (13.33%)
-
-Test serie  28: [u'40 0f 04 88 88 88 88'] * 5
-    Test   0 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of   5 (  0.00%)
-    Test   1 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of   5 (  0.00%)
-  => Total passed: 0 out of 10  (0.00%)
-
-Test serie  29: [u'40 0d 03 88 88 88 88'] * 5
-    Test   0 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of   5 (  0.00%)
-    Test   1 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   1 out of   5 ( 20.00%)
-  => Total passed: 1 out of 10  (10.00%)
-
-Test serie  30: [u'40 0b 07 88 88 88 88'] * 10
-    Test   0 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   5 out of  10 ( 50.00%)
-    Test   1 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-    Test   2 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-  => Total passed: 5 out of 30  (16.67%)
-
-Test serie  31: [u'40 0f 04 88 88 88 88'] * 10
-    Test   0 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-    Test   1 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-  => Total passed: 0 out of 20  (0.00%)
-
-Test serie  32: [u'40 0d 03 88 88 88 88'] * 10
-    Test   0 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
-    Test   1 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   4 out of  10 ( 40.00%)
-  => Total passed: 4 out of 20  (20.00%)
+Test serie  10: [u'88 88 88 88'] * 10
+    Test  68 :: cr4-5 bw125 sf7  crc1 pwr1 :: passed   5 out of  10 ( 50.00%)
+    Test  69 :: cr4-5 bw125 sf8  crc1 pwr1 :: passed   2 out of  10 ( 20.00%)
+    Test  70 :: cr4-5 bw125 sf12 crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test  71 :: cr4-7 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test  72 :: cr4-7 bw125 sf7  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test  73 :: cr4-6 bw125 sf6  crc1 pwr1 :: passed   0 out of  10 (  0.00%)
+    Test  74 :: cr4-6 bw125 sf7  crc1 pwr1 :: passed   4 out of  10 ( 40.00%)
+  => Total passed: 11 out of 70  (15.71%)
 
 
- ====== Total passed: 51 out of 413  (12.35%) ======
- Ran 1 tests in 278.085s
+ ====== Total passed: 75 out of 413  (18.16%) ======
+Ran 1 test in 612.239s

--- a/examples/qa_BasicTest_Data.xml
+++ b/examples/qa_BasicTest_Data.xml
@@ -3,616 +3,616 @@
     <TEST id="1">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf7_crc1_pwr1_000.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>80 0b 01 01 23 45 67 89 ab cd ef</expected-data-all>
-        <expected-hdr>80 0b 01</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 80 0b 01 -->
         <expected-data-only>01 23 45 67 89 ab cd ef</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="2">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf8_crc1_pwr1_000.cfile</file>
         <spreading-factor>8</spreading-factor>
-        <expected-data-all>80 0b 01 01 23 45 67 89 ab cd ef</expected-data-all>
-        <expected-hdr>80 0b 01</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 80 0b 01 -->
         <expected-data-only>01 23 45 67 89 ab cd ef</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="3">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf12_crc1_pwr1_000.cfile</file>
         <spreading-factor>12</spreading-factor>
-        <expected-data-all>80 0b 01 01 23 45 67 89 ab cd ef</expected-data-all>
-        <expected-hdr>80 0b 01</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 80 0b 01 -->
         <expected-data-only>01 23 45 67 89 ab cd ef</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="4">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf6_crc1_pwr1_000.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>80 0f 02 01 23 45 67 89 ab cd ef</expected-data-all>
-        <expected-hdr>80 0f 02</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 80 0f 02 -->
         <expected-data-only>01 23 45 67 89 ab cd ef</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="5">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf7_crc1_pwr1_000.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>80 0f 02 01 23 45 67 89 ab cd ef</expected-data-all>
-        <expected-hdr>80 0f 02</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 80 0f 02 -->
         <expected-data-only>01 23 45 67 89 ab cd ef</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="6">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf6_crc1_pwr1_000.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>80 0d 05 01 23 45 67 89 ab cd ef</expected-data-all>
-        <expected-hdr>80 0d 05</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 80 0d 05 -->
         <expected-data-only>01 23 45 67 89 ab cd ef</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="7">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf7_crc1_pwr1_000.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>80 0d 05 01 23 45 67 89 ab cd ef</expected-data-all>
-        <expected-hdr>80 0d 05</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 80 0d 05 -->
         <expected-data-only>01 23 45 67 89 ab cd ef</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="8">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf7_crc1_pwr1_001.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>30 0b 02 11 11 11</expected-data-all>
-        <expected-hdr>30 0b 02</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0b 02 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="9">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf8_crc1_pwr1_001.cfile</file>
         <spreading-factor>8</spreading-factor>
-        <expected-data-all>30 0b 02 11 11 11</expected-data-all>
-        <expected-hdr>30 0b 02</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0b 02 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="10">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf12_crc1_pwr1_001.cfile</file>
         <spreading-factor>12</spreading-factor>
-        <expected-data-all>30 0b 02 11 11 11</expected-data-all>
-        <expected-hdr>30 0b 02</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0b 02 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="11">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf6_crc1_pwr1_001.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>30 0f 01 11 11 11</expected-data-all>
-        <expected-hdr>30 0f 01</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0f 01 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="12">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf7_crc1_pwr1_001.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>30 0f 01 11 11 11</expected-data-all>
-        <expected-hdr>30 0f 01</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0f 01 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="13">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf6_crc1_pwr1_001.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>30 0d 06 11 11 11</expected-data-all>
-        <expected-hdr>30 0d 06</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0d 06 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="14">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf7_crc1_pwr1_001.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>30 0d 06 11 11 11</expected-data-all>
-        <expected-hdr>30 0d 06</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0d 06 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="15">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf7_crc1_pwr1_002.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>30 0b 02 11 11 11</expected-data-all>
-        <expected-hdr>30 0b 02</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0b 02 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="16">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf8_crc1_pwr1_002.cfile</file>
         <spreading-factor>8</spreading-factor>
-        <expected-data-all>30 0b 02 11 11 11</expected-data-all>
-        <expected-hdr>30 0b 02</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0b 02 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="17">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf12_crc1_pwr1_002.cfile</file>
         <spreading-factor>12</spreading-factor>
-        <expected-data-all>30 0b 02 11 11 11</expected-data-all>
-        <expected-hdr>30 0b 02</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0b 02 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="18">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf6_crc1_pwr1_002.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>30 0f 01 11 11 11</expected-data-all>
-        <expected-hdr>30 0f 01</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0f 01 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="19">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf7_crc1_pwr1_002.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>30 0f 01 11 11 11</expected-data-all>
-        <expected-hdr>30 0f 01</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0f 01 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="20">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf6_crc1_pwr1_002.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>30 0d 06 11 11 11</expected-data-all>
-        <expected-hdr>30 0d 06</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0d 06 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="21">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf7_crc1_pwr1_002.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>30 0d 06 11 11 11</expected-data-all>
-        <expected-hdr>30 0d 06</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 30 0d 06 -->
         <expected-data-only>11 11 11</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="22">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf7_crc1_pwr1_003.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0b 07 aa aa aa aa</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>aa aa aa aa</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="23">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf8_crc1_pwr1_003.cfile</file>
         <spreading-factor>8</spreading-factor>
-        <expected-data-all>40 0b 07 aa aa aa aa</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>aa aa aa aa</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="24">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf12_crc1_pwr1_003.cfile</file>
         <spreading-factor>12</spreading-factor>
-        <expected-data-all>40 0b 07 aa aa aa aa</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>aa aa aa aa</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="25">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf6_crc1_pwr1_003.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0f 04 aa aa aa aa</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>aa aa aa aa</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="26">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf7_crc1_pwr1_003.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0f 04 aa aa aa aa</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>aa aa aa aa</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="27">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf6_crc1_pwr1_003.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0d 03 aa aa aa aa</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>aa aa aa aa</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="28">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf7_crc1_pwr1_003.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0d 03 aa aa aa aa</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>aa aa aa aa</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="29">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf7_crc1_pwr1_004.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0b 07 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="30">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf8_crc1_pwr1_004.cfile</file>
         <spreading-factor>8</spreading-factor>
-        <expected-data-all>40 0b 07 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="31">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf12_crc1_pwr1_004.cfile</file>
         <spreading-factor>12</spreading-factor>
-        <expected-data-all>40 0b 07 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="32">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf6_crc1_pwr1_004.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0f 04 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="33">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf7_crc1_pwr1_004.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0f 04 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="34">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf6_crc1_pwr1_004.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0d 03 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="35">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf7_crc1_pwr1_004.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0d 03 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="36">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf7_crc1_pwr1_005.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0b 07 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="37">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf8_crc1_pwr1_005.cfile</file>
         <spreading-factor>8</spreading-factor>
-        <expected-data-all>40 0b 07 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="38">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf12_crc1_pwr1_005.cfile</file>
         <spreading-factor>12</spreading-factor>
-        <expected-data-all>40 0b 07 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="39">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf6_crc1_pwr1_005.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0f 04 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="40">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf7_crc1_pwr1_005.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0f 04 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="41">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf6_crc1_pwr1_005.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0d 03 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 03 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="42">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf7_crc1_pwr1_005.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0d 03 ff ff ff ff</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 03 -->
         <expected-data-only>ff ff ff ff</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="43">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf7_crc1_pwr1_006.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0b 07 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="44">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf8_crc1_pwr1_006.cfile</file>
         <spreading-factor>8</spreading-factor>
-        <expected-data-all>40 0b 07 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="45">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf12_crc1_pwr1_006.cfile</file>
         <spreading-factor>12</spreading-factor>
-        <expected-data-all>40 0b 07 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="46">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf6_crc1_pwr1_006.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0f 04 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="47">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf7_crc1_pwr1_006.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0f 04 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="48">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf6_crc1_pwr1_006.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0d 03 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="49">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf7_crc1_pwr1_006.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0d 03 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>3</expected-times>
     </TEST>
     <TEST id="50">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf7_crc1_pwr1_007.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0b 07 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="51">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf8_crc1_pwr1_007.cfile</file>
         <spreading-factor>8</spreading-factor>
-        <expected-data-all>40 0b 07 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="52">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf12_crc1_pwr1_007.cfile</file>
         <spreading-factor>12</spreading-factor>
-        <expected-data-all>40 0b 07 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="53">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf6_crc1_pwr1_007.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0f 04 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="54">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf7_crc1_pwr1_007.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0f 04 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="55">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf6_crc1_pwr1_007.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0d 03 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="56">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf7_crc1_pwr1_007.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0d 03 55 55 55 55</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>55 55 55 55</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="57">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf7_crc1_pwr1_008.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0b 07 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="58">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf8_crc1_pwr1_008.cfile</file>
         <spreading-factor>8</spreading-factor>
-        <expected-data-all>40 0b 07 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="59">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf12_crc1_pwr1_008.cfile</file>
         <spreading-factor>12</spreading-factor>
-        <expected-data-all>40 0b 07 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="60">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf6_crc1_pwr1_008.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0f 04 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="61">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf7_crc1_pwr1_008.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0f 04 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="62">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf6_crc1_pwr1_008.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0d 03 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="63">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf7_crc1_pwr1_008.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0d 03 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>1</expected-times>
     </TEST>
     <TEST id="61">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf7_crc1_pwr1_009.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0b 07 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="62">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf8_crc1_pwr1_009.cfile</file>
         <spreading-factor>8</spreading-factor>
-        <expected-data-all>40 0b 07 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="63">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf12_crc1_pwr1_009.cfile</file>
         <spreading-factor>12</spreading-factor>
-        <expected-data-all>40 0b 07 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="64">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf6_crc1_pwr1_009.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0f 04 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="65">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf7_crc1_pwr1_009.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0f 04 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="66">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf6_crc1_pwr1_009.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0d 03 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="67">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf7_crc1_pwr1_009.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0d 03 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>5</expected-times>
     </TEST>
     <TEST id="68">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf7_crc1_pwr1_010.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0b 07 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="69">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf8_crc1_pwr1_010.cfile</file>
         <spreading-factor>8</spreading-factor>
-        <expected-data-all>40 0b 07 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="70">
         <file>./examples/lora-samples/hackrf_cr4-5_bw125_sf12_crc1_pwr1_010.cfile</file>
         <spreading-factor>12</spreading-factor>
-        <expected-data-all>40 0b 07 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0b 07</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0b 07 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="71">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf6_crc1_pwr1_010.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0f 04 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="72">
         <file>./examples/lora-samples/hackrf_cr4-7_bw125_sf7_crc1_pwr1_010.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0f 04 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0f 04</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0f 04 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="73">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf6_crc1_pwr1_010.cfile</file>
         <spreading-factor>6</spreading-factor>
-        <expected-data-all>40 0d 03 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>
     <TEST id="74">
         <file>./examples/lora-samples/hackrf_cr4-6_bw125_sf7_crc1_pwr1_010.cfile</file>
         <spreading-factor>7</spreading-factor>
-        <expected-data-all>40 0d 03 88 88 88 88</expected-data-all>
-        <expected-hdr>40 0d 03</expected-hdr>
+        <expected-data-all />
+        <expected-hdr /><!-- 40 0d 03 -->
         <expected-data-only>88 88 88 88</expected-data-only>
         <expected-times>10</expected-times>
     </TEST>

--- a/python/qa_BasicTest_XML.py
+++ b/python/qa_BasicTest_XML.py
@@ -33,7 +33,7 @@ class qa_BasicTest_XML (gr_unittest.TestCase):
     #   Print received data, expected data and if they match.
     #   Also give feedback about successrate in the decoding (percentage correctly captured and decoded).
     #
-    def compareDataSets(self, total_data, expected_data, fromfile, cmpHDR):
+    def compareDataSets(self, total_data, expected_data, fromfile):
         global testResults
         total_passing = 0
 
@@ -45,7 +45,7 @@ class qa_BasicTest_XML (gr_unittest.TestCase):
 
             try:
                 data_str = " ".join("{:02x}".format(ord(n)) for n in total_data[idx])
-                self.assertEqual(val, data_str if cmpHDR else data_str[9:])
+                self.assertEqual(val, data_str if self.hasHDR else data_str[9:])
             except:
                 passed = False
 
@@ -59,29 +59,7 @@ class qa_BasicTest_XML (gr_unittest.TestCase):
         results = TestResultData(fromfile, total_passing, len(expected_data), float(total_passing) / len(expected_data) * 100.0)
         testResults[len(testResults) - 1].append(results)
         print ("\nPassed rate: {0:d} out of {1:d}  ({2:.2f}%)\n"
-                .format(results[1], results[2], results[3]))
-
-    #
-    #   Connect a filesource with the given file and run the flowgraph.
-    #   File is acquired from the file_sink block and saved as .cfile (complex IQ data).
-    #
-    def runWithFileSourceAndData(self, infile, SpreadingFactor, cmpHDR):
-        print "Starting test from data in: {0:s}\n".format(infile)
-
-        if os.path.isfile(infile):
-            self.file_source.close()
-            self.file_source.open(infile, False)
-            self.sf = SpreadingFactor
-            self.lora_lora_receiver_0.set_sf(self.sf)
-            self.tb.run ()
-
-            total_data = self.gatherFromSocket(test_series[len(test_series) - 1][1])
-            self.compareDataSets(total_data,
-                                 test_series[len(test_series) - 1][0] * test_series[len(test_series) - 1][1],
-                                 os.path.splitext(os.path.basename(infile))[0],
-                                 cmpHDR)
-        else:
-            raise Exception("Error file does not exists!")
+                .format(results.passing, results.total, results.rate))
 
     #
     #   Set up flowgraph before Unit Test. (Gets threrefore called before EVERY test)
@@ -102,6 +80,9 @@ class qa_BasicTest_XML (gr_unittest.TestCase):
         #self.symbols_per_sec = self.bw  / (2**self.sf)
         self.offset          = -(self.capture_freq - self.target_freq)
         #self.bitrate         = self.sf * (1 / (2**self.sf / self.bw ))
+        self.hasHDR          = True
+
+        self.inputFile       = "./"
 
         # Socket connection for sink
         self.host            = "127.0.0.1"
@@ -112,8 +93,6 @@ class qa_BasicTest_XML (gr_unittest.TestCase):
         self.server.bind((self.host, self.port))
         self.server.setblocking(0)  ## or self.server.settimeout(0.5)  ?
 
-        self.lastTestComplete = False
-
         self.logFile         = './examples/qa_BasicTest.log'
 
         self.xmlFile         = './examples/qa_BasicTest_Data.xml'
@@ -123,95 +102,64 @@ class qa_BasicTest_XML (gr_unittest.TestCase):
             self.xmlTests = xmltodict.parse(f.read())["lora-test-data"]["TEST"]
             f.close()
         else:
-            raise Exception("[BasicTest_XML] '" + self.xmlFile + "' does not exists!")
-
-        self.prevData       = ""
-
-        ##################################################
-        # Blocks                                         #
-        ##################################################
-        self.tb = gr.top_block ()
-
-        self.file_source = blocks.file_source(gr.sizeof_gr_complex*1, "./", False) # Repeat input: True/False
-        self.lora_lora_receiver_0         = lora.lora_receiver(self.samp_rate, self.capture_freq, self.offset, self.sf, self.samp_rate)
-        self.blocks_throttle_0            = blocks.throttle(gr.sizeof_gr_complex*1, self.samp_rate, True)
-        self.blocks_message_socket_sink_0 = lora.message_socket_sink()
-
-        self.tb.connect(     (self.file_source, 0),                 (self.blocks_throttle_0, 0))
-        self.tb.connect(     (self.blocks_throttle_0, 0),           (self.lora_lora_receiver_0, 0))
-        self.tb.msg_connect( (self.lora_lora_receiver_0, 'frames'), (self.blocks_message_socket_sink_0, 'in'))
+            raise Exception("[BasicTest_XML] '" + self.xmlFile + "' does not exist!")
 
     #
     #   Clean-up flowgraph after Unit Test. (Gets threrefore called after EVERY test)
     #
-    #   If last test was completed, report results.
+    #   Because tests are completed, report results.
     #
     def tearDown (self):
         self.tb = None
         self.xmlTests = None
         self.server.close()
+        
+        flog       = open(self.logFile, 'a')
+        passed_t_a = 0
+        passed_t   = 0
+        total_t_a  = 0
+        total_t    = 0
+        stro = ("-" * 8) + " Test Results on " + str(datetime.datetime.now())[:19] + " " + ("-" * 9)
+        print(stro)
+        flog.write(stro + '\n')
 
-        if self.lastTestComplete:
-            flog = open(self.logFile, 'a')
-            passed_t_a = 0
-            passed_t   = 0
-            total_t_a  = 0
-            total_t    = 0
-            stro = ("-" * 8) + " Test Results on " + str(datetime.datetime.now())[:19] + " " + ("-" * 9)
+        for j, serie in enumerate(testResults):
+            total_t = passed_t = 0
+
+            stro = ("Test serie {0: 3d}: {1:s} * {2:d}"
+                        .format(j, test_series[j].data, test_series[j].times))
             print(stro)
             flog.write(stro + '\n')
 
-            for j, serie in enumerate(testResults):
-                total_t = passed_t = 0
-
-                stro = ("Test serie {0: 3d}: {1:s} * {2:d}"
-                            .format(j, test_series[j][0], test_series[j][1]))
+            for i, x in enumerate(serie):
+                passed_t += x[1]
+                total_t  += x[2]
+                stro = ("    Test {0: 3d} :: {1:5s} {2:5s} {3:4s} {4:4s} {5:4s} :: passed {6: 3d} out of {7: 3d} ({8:6.2f}%)"
+                            .format(i, *(x[0].split('_')[1:-1] + [x[1]] + [x[2]] + [x[3]])))
                 print(stro)
                 flog.write(stro + '\n')
 
-                for i, x in enumerate(serie):
-                    passed_t += x[1]
-                    total_t  += x[2]
-                    stro = ("    Test {0: 3d} :: {1:5s} {2:5s} {3:4s} {4:4s} {5:4s} :: passed {6: 3d} out of {7: 3d} ({8:6.2f}%)"
-                                .format(i, *(x[0].split('_')[1:-1] + [x[1]] + [x[2]] + [x[3]])))
-                    print(stro)
-                    flog.write(stro + '\n')
-
-                passed_t_a += passed_t
-                total_t_a  += total_t
-                stro = ("  => Total passed: {0:d} out of {1:d}  ({2:.2f}%)\n"
-                            .format(passed_t, total_t, float(passed_t) / (total_t if total_t else 1.0) * 100.0))
-                print(stro)
-                flog.write(stro + '\n')
-
-            stro = ("\n ====== Total passed: {0:d} out of {1:d}  ({2:.2f}%) ======"
-                        .format(passed_t_a, total_t_a, float(passed_t_a) / (total_t_a if total_t_a else 1.0) * 100.0))
+            passed_t_a += passed_t
+            total_t_a  += total_t
+            stro = ("  => Total passed: {0:d} out of {1:d}  ({2:.2f}%)\n"
+                        .format(passed_t, total_t, float(passed_t) / (total_t if total_t else 1.0) * 100.0))
             print(stro)
-            flog.write(stro + '\n\n')
-            flog.close()
+            flog.write(stro + '\n')
 
-            print ("Log appended to: " + self.logFile)
+        stro = ("\n ====== Total passed: {0:d} out of {1:d}  ({2:.2f}%) ======"
+                    .format(passed_t_a, total_t_a, float(passed_t_a) / (total_t_a if total_t_a else 1.0) * 100.0))
+        print(stro)
+        flog.write(stro + '\n\n')
+        flog.close()
 
-
-
-###################################################################################################
-#   Unit tests                                                                                    #
-#       These assume a directory "./examples/lora-samples"                                        #
-#       with the specified .cfiles existing.                                                      #
-###################################################################################################
-    # def test_032 (self):
-    #     testResults.append( [] )
-    #     test_series.append( TestSerieSettings(["40 0d 03 88 88 88 88"] , 10) )
-    #
-    #     self.runWithFileSourceAndData('./examples/lora-samples/hackrf_cr4-6_bw125_sf6_crc1_pwr1_010.cfile', 6)
-    #     self.runWithFileSourceAndData('./examples/lora-samples/hackrf_cr4-6_bw125_sf7_crc1_pwr1_010.cfile', 7)
-    #
-    #     self.lastTestComplete = True
+        print ("Log appended to: " + self.logFile)
 
     ###############################################################################################
     #   Unit tests series from qa_BasicTest_Data.xml                                              #
     ###############################################################################################
     def test_000 (self):
+        prevData = ""
+
         for test in self.xmlTests:
             # print (("Test {0: 3d}\n"
             #         + "  File:     {1:s}\n"
@@ -225,31 +173,58 @@ class qa_BasicTest_XML (gr_unittest.TestCase):
             #                 test['expected-data-only'], int(test['expected-times']))
             #       )
 
-            data = test['expected-data-all']
-            hasHDR = True
+            self.sf        = int(test['spreading-factor'])
+            self.inputFile = str(test['file'])
+            self.hasHDR    = True
+            data           = test['expected-data-all']
 
             if not data:
                 data = test['expected-hdr']
                 if not data:
-                    hasHDR = False
+                    self.hasHDR = False
                     data = test['expected-data-only']
                 else:
                     data = data + " " + test['expected-data-only']
 
-            infile = str(test['file'])
-
-            if data and os.path.isfile(infile):
-                if data != self.prevData:
+            if data and os.path.isfile(self.inputFile):
+                if data != prevData:
                     testResults.append( [] )
                     test_series.append( TestSerieSettings([data], int(test['expected-times'])) )
-                    self.prevData = data
-                self.runWithFileSourceAndData(infile, int(test['spreading-factor']), hasHDR)
+                    prevData = data
+
+                print "++++++++++  Starting test {0: 3d} from data in: \n  {1:s}\n".format(int(test['@id']), self.inputFile)
+
+                ##################################################
+                # Blocks                                         #
+                ##################################################
+                self.tb = gr.top_block ()
+
+                self.file_source                  = blocks.file_source(gr.sizeof_gr_complex*1, self.inputFile, False) # Repeat input: True/False
+                self.lora_lora_receiver_0         = lora.lora_receiver(self.samp_rate, self.capture_freq, self.offset, self.sf, self.samp_rate)
+                self.blocks_throttle_0            = blocks.throttle(gr.sizeof_gr_complex*1, self.samp_rate, True)
+                self.blocks_message_socket_sink_0 = lora.message_socket_sink()
+
+                self.tb.connect(     (self.file_source, 0),                 (self.blocks_throttle_0, 0))
+                self.tb.connect(     (self.blocks_throttle_0, 0),           (self.lora_lora_receiver_0, 0))
+                self.tb.msg_connect( (self.lora_lora_receiver_0, 'frames'), (self.blocks_message_socket_sink_0, 'in'))
+
+                self.tb.run ()
+
+                total_data = self.gatherFromSocket(test_series[len(test_series) - 1].times)
+                self.compareDataSets(total_data,
+                                     test_series[len(test_series) - 1].data * test_series[len(test_series) - 1].times,
+                                     os.path.splitext(os.path.basename(self.inputFile))[0])
+
+                self.tb = None
             else:
                 print("No test data or file does not exist, skipping test {0: 3d}...".format(int(test['@id'])))
 
-        self.lastTestComplete = True
 
-
+###################################################################################################
+#   Unit tests                                                                                    #
+#       These assume a directory "./examples/lora-samples"                                        #
+#       with the specified .cfiles existing.                                                      #
+###################################################################################################
 if __name__ == '__main__':
     global testResults
     testResults = []


### PR DESCRIPTION
```
~ Fixed the testing to properly create and destroy a tob_block so the
        correct spreading factor can be set.
~ Removed explicit expected-data-all and expected-hdr in xml file. This
        way the testing will only be done on the actual data and not the PHY HDR
        (since its currently unsure what the correct HDR should be)
--------
~ Changed test id when printing log to actual id from xml file (for easy look-up)
~ Tests are now properly grouped by data and the times the data is expected
```