### PR TITLE
Write bytes instead of complex samples

### DIFF
--- a/lib/message_file_sink_impl.cc
+++ b/lib/message_file_sink_impl.cc
@@ -716,10 +716,10 @@ namespace gr {
      * Incoming message handler
      */
     void message_file_sink_impl::msg_handler(pmt::pmt_t msg) {
-        uint32_t length = pmt::length(msg);
-        // std::cout << "Writing " << length / sizeof(gr_complex) << " samples" << std::endl;
-        gr_complex* raw_samples = (gr_complex *)pmt::blob_data(msg);
-        d_file.write(reinterpret_cast<const char *>(raw_samples), length);
+        const char* data = (const char*) pmt::blob_data(msg);
+        size_t size = pmt::blob_length(msg);
+        d_file.write(data, size);
+        d_file.flush();
     }
 
   } /* namespace lora */


### PR DESCRIPTION
It appears the Message File Sink block was originally intended to write out messages containing complex samples, but at this point the LoRa Receiver block produces bytes. I've rewritten the message handler accordingly. I also added a call to `flush()` since the sink's destructor isn't always called when a flow graph terminates, and so packets can be lost.