### PR TITLE
Add boost::placeholders namespace to _1

### DIFF
--- a/lib/controller_impl.cc
+++ b/lib/controller_impl.cc
@@ -46,7 +46,7 @@ namespace gr {
         d_parent = parent;
         d_port = pmt::intern("control");
         message_port_register_in(d_port);
-        set_msg_handler(d_port, boost::bind(&controller_impl::handle_control, this, _1));
+        set_msg_handler(d_port, boost::bind(&controller_impl::handle_control, this, boost::placeholders::_1));
     }
 
     void controller_impl::handle_control(pmt::pmt_t msg){

--- a/lib/message_file_sink_impl.cc
+++ b/lib/message_file_sink_impl.cc
@@ -699,7 +699,7 @@ namespace gr {
               gr::io_signature::make(0, 0, 0)) {
 
         message_port_register_in(pmt::mp("in"));
-        set_msg_handler(pmt::mp("in"), boost::bind(&message_file_sink_impl::msg_handler, this, _1));
+        set_msg_handler(pmt::mp("in"), boost::bind(&message_file_sink_impl::msg_handler, this, boost::placeholders::_1));
 
         d_file.open(path.c_str(), std::ios::out | std::ios::binary);
     }

--- a/lib/message_socket_sink_impl.cc
+++ b/lib/message_socket_sink_impl.cc
@@ -47,7 +47,7 @@ namespace gr {
             d_layer(layer) {
 
             message_port_register_in(pmt::mp("in"));
-            set_msg_handler(pmt::mp("in"), boost::bind(&message_socket_sink_impl::handle, this, _1));
+            set_msg_handler(pmt::mp("in"), boost::bind(&message_socket_sink_impl::handle, this, boost::placeholders::_1));
 
             d_socket = socket(AF_INET, SOCK_DGRAM, 0);
 


### PR DESCRIPTION
Placeholders are not exported to global namespace since boost 1.73.
See [boost/bind.hpp](https://github.com/boostorg/bind/blob/e3cf787dff2684e7bc45bb84dfa390514656b110/include/boost/bind.hpp#L36):

```cpp
BOOST_PRAGMA_MESSAGE(
  "The practice of declaring the Bind placeholders (_1, _2, ...) "
  "in the global namespace is deprecated. Please use "
  "<boost/bind/bind.hpp> + using namespace boost::placeholders, "
  "or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior."
)
```

The placeholders are always defined in boost::placeholders namesapce.
And they were exported to the global namespace before 1.73. So, adding
the namespace will not affect the compilation with earlier version.

In my case, I met the following error while building with boost 1.75:

```
gr-lora/lib/controller_impl.cc:49:85: error: ‘_1’ was not declared in this scope
   49 |         set_msg_handler(d_port, boost::bind(&controller_impl::handle_control, this, _1));
```
